### PR TITLE
There is no need to explicitly kill the subscribe command

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,18 +338,9 @@ kubectl run dev-utils --image=projectriff/dev-utils:latest --generator=run-pod/v
 Subscribe to the orders:
 
 ```
-kubectl exec dev-utils -n default -- subscribe orders -n default --payload-as-string
+kubectl exec dev-utils -it -n default -- subscribe orders -n default --payload-as-string
 ```
-
-#### When you're done watching the orders stream
-
 > Hit `ctrl-c` to stop subscribing
-
-Kill the subscription:
-
-```
-kubectl exec dev-utils -- sh -c 'kill $(pidof subscribe)'
-```
 
 ### Go shopping!
 

--- a/manual-test.md
+++ b/manual-test.md
@@ -73,5 +73,5 @@ kubectl exec dev-utils -n default -- subscribe orders -n default --payload-as-st
 Kill the subscription:
 
 ```
-kubectl exec dev-utils -- sh -c 'kill $(pidof subscribe)'
+kubectl exec dev-utils -- pkill -SIGTERM subscribe
 ```

--- a/no-buy-detector.md
+++ b/no-buy-detector.md
@@ -50,15 +50,6 @@ kubectl run dev-utils --image=projectriff/dev-utils:latest --generator=run-pod/v
 Subscribe to the no-buy events:
 
 ```
-kubectl exec dev-utils -n default -- subscribe no-buy -n default --payload-as-string
+kubectl exec dev-utils -it -n default -- subscribe no-buy -n default --payload-as-string
 ```
-
-#### When you're done watching the no-buy stream
-
 > Hit `ctrl-c` to stop subscribing
-
-Kill the subscription:
-
-```
-kubectl exec dev-utils -- sh -c 'kill $(pidof subscribe)'
-```

--- a/trend-detector.md
+++ b/trend-detector.md
@@ -55,15 +55,7 @@ kubectl run dev-utils --image=projectriff/dev-utils:latest --generator=run-pod/v
 Subscribe to the popular-products:
 
 ```
-kubectl exec dev-utils -n default -- subscribe popular-products -n default --payload-as-string
+kubectl exec dev-utils -it -n default -- subscribe popular-products -n default --payload-as-string
 ```
-
-#### When you're done watching the popular-products stream
 
 > Hit `ctrl-c` to stop subscribing
-
-Kill the subscription:
-
-```
-kubectl exec dev-utils -- sh -c 'kill $(pidof subscribe)'
-```


### PR DESCRIPTION
when the kubectl exec command passes the "-it" flag, ctrl-c will kill
the subscribe command