### PR TITLE
Update release artifact location

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cd riff-shopping-demo
 
 Install riff with Knative, Core and Streaming runtimes plus their dependencies.
 
-1. Follow the instructions for your Kubernetes installation from the [riff getting started guides](https://projectriff.io/docs/latest/getting-started). This install riff Build and required dependencies plus the Knative Runtime and its dependencies.
+1. Follow the instructions for your Kubernetes installation from the [riff getting started guides](https://projectriff.io/docs/latest/getting-started). This installs riff Build and required dependencies plus the Knative Runtime and its dependencies.
 
 1. Install the Core runtime by following instructions in the [Core Runtime Install section](https://projectriff.io/docs/latest/runtimes/core#install).
 

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ cd riff-shopping-demo
 
 Install riff with Knative, Core and Streaming runtimes plus their dependencies.
 
-1. Follow the instructions for your Kubernetes installation from the [riff getting started guides](https://projectriff.io/docs/latest/getting-started).
+1. Follow the instructions for your Kubernetes installation from the [riff getting started guides](https://projectriff.io/docs/latest/getting-started). This install riff Build and required dependencies plus the Knative Runtime and its dependencies.
 
-2. Install the Core runtime by following instructions in the [Core Runtime Install section](https://projectriff.io/docs/latest/runtimes/core#install).
+1. Install the Core runtime by following instructions in the [Core Runtime Install section](https://projectriff.io/docs/latest/runtimes/core#install).
 
-3. Install the Streaming runtime by following instructions in the [Streaming Runtime Install section](https://projectriff.io/docs/latest/runtimes/streaming#install).
+1. Install the Streaming runtime by following instructions in the [Streaming Runtime Install section](https://projectriff.io/docs/latest/runtimes/streaming#install).
 
 ### Add Docker Hub credentials for builds
 

--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ cd riff-shopping-demo
 
 ### Install riff
 
-Install riff with Core, Knative and Streaming runtimes plus their dependencies.
+Install riff with Knative, Core and Streaming runtimes plus their dependencies.
 
 1. Follow the instructions for your Kubernetes installation from the [riff getting started guides](https://projectriff.io/docs/latest/getting-started).
 
-1. Install the Core runtime by following instructions in the [Core Runtime Install section](https://projectriff.io/docs/latest/runtimes/core#install).
+2. Install the Core runtime by following instructions in the [Core Runtime Install section](https://projectriff.io/docs/latest/runtimes/core#install).
 
-1. Install the Streaming runtime by following instructions in the [Streaming Runtime Install section](https://projectriff.io/docs/latest/runtimes/streaming#install).
+3. Install the Streaming runtime by following instructions in the [Streaming Runtime Install section](https://projectriff.io/docs/latest/runtimes/streaming#install).
 
 ### Add Docker Hub credentials for builds
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,13 @@ cd riff-shopping-demo
 
 ### Install riff
 
-Install riff and all dependent packages including cert-manager, kpack, keda, kafka, riff-build, istio and core, knative and streaming runtimes.
+Install riff with Core, Knative and Streaming runtimes plus their dependencies.
 
-Follow the instructions for your Kubernetes installation from the [riff getting started guides](https://projectriff.io/docs/latest/getting-started).
+1. Follow the instructions for your Kubernetes installation from the [riff getting started guides](https://projectriff.io/docs/latest/getting-started).
+
+1. Install the Core runtime by following instructions in the [Core Runtime Install section](https://projectriff.io/docs/latest/runtimes/core#install).
+
+1. Install the Streaming runtime by following instructions in the [Streaming Runtime Install section](https://projectriff.io/docs/latest/runtimes/streaming#install).
 
 ### Add Docker Hub credentials for builds
 

--- a/README.md
+++ b/README.md
@@ -102,17 +102,7 @@ cd riff-shopping-demo
 
 Install riff and all dependent packages including cert-manager, kpack, keda, kafka, riff-build, istio and core, knative and streaming runtimes.
 
-For a cluster that supports LoadBalancer use:
-
-```
-./riff-kapp-install.sh
-```
-
-For a cluster like "Minikube" or "Docker Desktop" that doesn't support LoadBalancer use:
-
-```
-./riff-kapp-install.sh --node-port
-```
+Follow the instructions for your Kubernetes installation from the [riff getting started guides](https://projectriff.io/docs/latest/getting-started).
 
 ### Add Docker Hub credentials for builds
 
@@ -126,12 +116,20 @@ riff credentials apply docker-push --docker-hub $DOCKER_USER --set-default-image
 ### Install inventory database
 
 ```
-helm install --name inventory-db --namespace default --set postgresqlDatabase=inventory stable/postgresql
+helm install --name inventory-db --namespace default --set postgresqlDatabase=inventory stable/postgresql --wait
 ```
 
 > NOTE: If you delete the database using `helm delete --purge inventory-db` then you also need to clear the persistent volume claim for the database, or you won't be able to log in if you create a new database instance with the same name.
 >
 > Delete the PVC with `kubectl delete pvc data-inventory-db-postgresql-0`.
+
+### Install kafka
+
+We create a single node Kafka instance in the `kafka` namespace.
+
+```
+helm install --name kafka --namespace kafka incubator/kafka --set replicas=1 --set zookeeper.replicaCount=1 --wait
+```
 
 ### Create kafka-provider
 
@@ -227,7 +225,7 @@ Lookup the gateway for the kafka-provider:
 
 ```
 gateway=$(kubectl get svc --no-headers -o custom-columns=NAME:.metadata.name \
-  -l streaming.projectriff.io/kafka-provider-gateway=franz)  
+  -l streaming.projectriff.io/kafka-provider-gateway=franz)
 ```
 
 Once we have the `gateway` variable set, we can create the HTTP source:
@@ -312,12 +310,6 @@ riff streaming processor create cart \
   --input checkout-events \
   --output orders \
   --tail
-```
-
-> NOTE: If there are issues with processor scaling then you can use a plain Deployment resource instead of the riff Streaming Processor. Use the command below:
-
-```
-kubectl apply -f https://raw.githubusercontent.com/projectriff-demo/demo/master/deployment-cart-processor.yaml
 ```
 
 ### Watch the orders stream

--- a/riff-kapp-delete.sh
+++ b/riff-kapp-delete.sh
@@ -9,9 +9,6 @@ kubectl delete knative --all-namespaces --all || true
 kapp delete -y -n apps -a riff-streaming-runtime
 kapp delete -y -n apps -a keda
 
-# kafka
-kapp delete -y -n apps -a kafka
-
 # riff knative runtime
 kapp delete -y -n apps -a riff-knative-runtime
 kapp delete -y -n apps -a knative

--- a/riff-kapp-install.sh
+++ b/riff-kapp-install.sh
@@ -42,30 +42,30 @@ else
 fi
 
 # build
-retry kapp deploy -y -n apps -a cert-manager -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/cert-manager.yaml
-kapp deploy -y -n apps -a kpack -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/kpack.yaml
-kapp deploy -y -n apps -a riff-builders -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/riff-builders.yaml
-kapp deploy -y -n apps -a riff-build -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/riff-build.yaml
+retry kapp deploy -y -n apps -a cert-manager -f https://storage.googleapis.com/projectriff/release/${riff_version}/cert-manager.yaml
+kapp deploy -y -n apps -a kpack -f https://storage.googleapis.com/projectriff/release/${riff_version}/kpack.yaml
+kapp deploy -y -n apps -a riff-builders -f https://storage.googleapis.com/projectriff/release/${riff_version}/riff-builders.yaml
+kapp deploy -y -n apps -a riff-build -f https://storage.googleapis.com/projectriff/release/${riff_version}/riff-build.yaml
 
 # istio -- use '--node-port' for clusters that don't support LoadBalancer 
 if [ $type = "NodePort" ]; then
   echo "Installing Istio with NodePort"
-  ytt -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/istio.yaml -f https://storage.googleapis.com/projectriff/charts/overlays/service-nodeport.yaml --file-mark istio.yaml:type=yaml-plain | kapp deploy -n apps -a istio -f - -y
+  ytt -f https://storage.googleapis.com/projectriff/release/${riff_version}/istio.yaml -f https://storage.googleapis.com/projectriff/charts/overlays/service-nodeport.yaml --file-mark istio.yaml:type=yaml-plain | kapp deploy -n apps -a istio -f - -y
 else
   echo "Installing Istio with LoadBalancer"
-  kapp deploy -y -n apps -a istio -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/istio.yaml
+  kapp deploy -y -n apps -a istio -f https://storage.googleapis.com/projectriff/release/${riff_version}/istio.yaml
 fi
 
 # riff core runtime
-kapp deploy -y -n apps -a riff-core-runtime -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/riff-core-runtime.yaml
+kapp deploy -y -n apps -a riff-core-runtime -f https://storage.googleapis.com/projectriff/release/${riff_version}/riff-core-runtime.yaml
 
 # riff knative runtime
-kapp deploy -y -n apps -a knative -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/knative.yaml
-kapp deploy -y -n apps -a riff-knative-runtime -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/riff-knative-runtime.yaml
+kapp deploy -y -n apps -a knative -f https://storage.googleapis.com/projectriff/release/${riff_version}/knative.yaml
+kapp deploy -y -n apps -a riff-knative-runtime -f https://storage.googleapis.com/projectriff/release/${riff_version}/riff-knative-runtime.yaml
 
 # kafka
-kapp deploy -y -n apps -a kafka -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/kafka.yaml
+kapp deploy -y -n apps -a kafka -f https://storage.googleapis.com/projectriff/release/${riff_version}/kafka.yaml
 
 # riff streaming runtime
-kapp deploy -y -n apps -a keda -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/keda.yaml
-kapp deploy -y -n apps -a riff-streaming-runtime -f https://storage.googleapis.com/projectriff/charts/uncharted/${riff_version}/riff-streaming-runtime.yaml
+kapp deploy -y -n apps -a keda -f https://storage.googleapis.com/projectriff/release/${riff_version}/keda.yaml
+kapp deploy -y -n apps -a riff-streaming-runtime -f https://storage.googleapis.com/projectriff/release/${riff_version}/riff-streaming-runtime.yaml

--- a/riff-kapp-install.sh
+++ b/riff-kapp-install.sh
@@ -63,9 +63,6 @@ kapp deploy -y -n apps -a riff-core-runtime -f https://storage.googleapis.com/pr
 kapp deploy -y -n apps -a knative -f https://storage.googleapis.com/projectriff/release/${riff_version}/knative.yaml
 kapp deploy -y -n apps -a riff-knative-runtime -f https://storage.googleapis.com/projectriff/release/${riff_version}/riff-knative-runtime.yaml
 
-# kafka
-kapp deploy -y -n apps -a kafka -f https://storage.googleapis.com/projectriff/release/${riff_version}/kafka.yaml
-
 # riff streaming runtime
 kapp deploy -y -n apps -a keda -f https://storage.googleapis.com/projectriff/release/${riff_version}/keda.yaml
 kapp deploy -y -n apps -a riff-streaming-runtime -f https://storage.googleapis.com/projectriff/release/${riff_version}/riff-streaming-runtime.yaml


### PR DESCRIPTION
Link to the getting-started-guide for install instructions.

Also install kafka with helm instead of our release yaml that is used for internal testing.
